### PR TITLE
Improvements using Xarray's native functions

### DIFF
--- a/bottomdetection/bottom_annotation.py
+++ b/bottomdetection/bottom_annotation.py
@@ -11,30 +11,21 @@ import numpy as np
 from bottomdetection.annotation import Annotation
 
 
-def to_bottom_annotation(zarr_data, bottom_depths):
+def to_bottom_annotation(bottom_depths):
     """
     Creates annotation with a mask for the bottom.
     """
 
-    ping_time = zarr_data['ping_time']
-    channel_ids = zarr_data['channelID'].data
+    df = bottom_depths.to_dataframe("mask_depth_upper")
 
-    annotation = Annotation()
+    df.reset_index(level=0, inplace=True)
+    df = df.rename(columns={'ping_time': 'pingTime'})
 
-    for i, bottom_depth in enumerate(bottom_depths):
-        if np.isnan(bottom_depth):
-            continue
-        time = np.datetime64(ping_time[i].data)
-        for channel_id in channel_ids:
-            annotation.append(
-                pingTime=time,
-                mask_depth_upper=bottom_depth,
-                mask_depth_lower=9999,
-                priority=2,
-                acousticCat=999,
-                proportion=1,
-                ID='bottom',
-                ChannelID=channel_id,
-            )
+    df = df.drop(columns=['latitude', 'longitude', 'raw_file', 'frequency'])
+    df = df.assign(mask_depth_lower = 9999,
+                priority = 2,
+                acousticCat = 999,
+                proportion = 1,
+                ID = 'bottom')
 
-    return annotation
+    return df

--- a/bottomdetection/bottom_detection_main.py
+++ b/bottomdetection/bottom_detection_main.py
@@ -21,7 +21,7 @@ def run(zarr_file, out_file, bottom_algorithm):
 
     bottom_depths = detect_bottom(zarr_data, bottom_algorithm)
 
-    annotation = bottom_annotation.to_bottom_annotation(zarr_data, bottom_depths)
+    annotation = bottom_annotation.to_bottom_annotation(bottom_depths)
     print('')
     print('Annotation:\n' + str(annotation))
 
@@ -40,8 +40,7 @@ def detect_bottom(zarr_data, bottom_algorithm):
     raise ValueError('Unknown bottom algorithm: ' + bottom_algorithm)
 
 
-def write_to_file(annotation: Annotation, file):
-    df = annotation.to_data_frame()
+def write_to_file(df, file):
 
     if file.endswith('.csv'):
         df.to_csv(file)

--- a/bottomdetection/bottom_detection_main.py
+++ b/bottomdetection/bottom_detection_main.py
@@ -16,7 +16,7 @@ from bottomdetection.annotation import Annotation
 
 
 def run(zarr_file, out_file, bottom_algorithm):
-    zarr_data = xr.open_zarr(zarr_file)
+    zarr_data = xr.open_zarr(zarr_file, chunks={'frequency': 'auto', 'ping_time': 'auto', 'range': -1})
     print(zarr_data)
 
     bottom_depths = detect_bottom(zarr_data, bottom_algorithm)

--- a/bottomdetection/simple_bottom_detector.py
+++ b/bottomdetection/simple_bottom_detector.py
@@ -12,9 +12,15 @@ import xarray as xr
 
 def detect_bottom(zarr_data):
     sv = zarr_data.sv
-    log_sv = 10 * np.log10(sv)
-    depth_ranges, indices = detect_bottom_single_channel(log_sv[0], -31)
-    depth_ranges_back_step, indices_back_step = back_step(sv[0], indices, 0.001)
+    sv0 = sv[0]
+    #log_sv = 10 * np.log10(sv)
+    threshold_log_sv = -31
+    threshold_sv = 10 ** (threshold_log_sv / 10)
+
+    depth_ranges, indices = detect_bottom_single_channel(sv0, threshold_sv)
+
+    depth_ranges_back_step, indices_back_step = back_step(sv0, indices, 0.001)
+
     offset = 0.5
     bottom_depths = depth_ranges_back_step + zarr_data['heave'] + zarr_data['transducer_draft'][0] - offset
     return bottom_depths

--- a/bottomdetection/simple_bottom_detector.py
+++ b/bottomdetection/simple_bottom_detector.py
@@ -17,7 +17,7 @@ def detect_bottom(zarr_data):
     depth_ranges_back_step, indices_back_step = back_step(sv[0], indices, 0.001)
     offset = 0.5
     bottom_depths = depth_ranges_back_step + zarr_data['heave'] + zarr_data['transducer_draft'][0] - offset
-    return bottom_depths.data
+    return bottom_depths
 
 
 def detect_bottom_single_channel(channel_sv: xr.DataArray, threshold: float, minimum_range=10):


### PR DESCRIPTION
I'm proposing two modifications to speed up processing:

1. Remove loop in `back_step()` and use Xarray's vectorized `apply_ufunc` instead. I've enable Dask automatic parallelization too. Therefore, in theory, we can load a whole cruise Zarr/NetCDF file with chunks to save memory and process it in just one go.
2. Remove loop in `to_bottom_annotation()`. However, this means that we skip  the `Annotation` class. However, we can keep using the `Annotation` class if it's desirable while still going loop-less.