### PR TITLE
New fixes for the bottom classifiers

### DIFF
--- a/bottomdetection/bottom_annotation.py
+++ b/bottomdetection/bottom_annotation.py
@@ -18,13 +18,12 @@ def to_bottom_annotation(channel_id: str, bottom_depths: xr.DataArray) -> pd.Dat
     df = bottom_depths.to_dataframe('mask_depth_upper')
 
     df.reset_index(level=0, inplace=True)
-    df = df.rename(columns={'ping_time': 'pingTime'})
 
     df = df.assign(mask_depth_lower=9999,
                    priority=2,
-                   acousticCat=999,
+                   acoustic_category=999,
                    proportion=1,
-                   ID='bottom',
-                   ChannelID=channel_id)
+                   object_id='bottom',
+                   channel_id=channel_id)
 
     return df

--- a/bottomdetection/bottom_detection_main.py
+++ b/bottomdetection/bottom_detection_main.py
@@ -24,7 +24,7 @@ def run(zarr_file: str, out_file: str, bottom_algorithm: str):
     print('\n\nBottom depth:')
     print(bottom_depth)
 
-    annotation = bottom_annotation.to_bottom_annotation(zarr_data['channelID'][0].values, bottom_depth)
+    annotation = bottom_annotation.to_bottom_annotation(zarr_data['channel_id'][0].values, bottom_depth)
     print('\n\nAnnotation:')
     print(annotation)
 

--- a/bottomdetection/docker_main.py
+++ b/bottomdetection/docker_main.py
@@ -9,6 +9,7 @@ Licensed under the MIT license.
 import os
 import sys
 import dask
+import shutil
 
 from dask.distributed import Client
 
@@ -27,10 +28,18 @@ if __name__ == "__main__":
     in_dir = os.path.expanduser("/in_dir")
     out_dir = os.path.expanduser("/out_dir")
 
-    dask.config.set({'temporary_directory': out_dir})
+    # Setting dask
+    tmp_dir = os.path.expanduser(out_dir + "/tmp")
+
+    dask.config.set({'temporary_directory': tmp_dir})
     client = Client()
     print(client)
 
     bottom_detection_main.run(zarr_file=in_dir + '/' + input_name,
                               out_file=out_dir + '/' + output_name,
                               bottom_algorithm=algorithm)
+
+    # Cleaning up
+    client.close()
+    if os.path.exists(tmp_dir):
+        shutil.rmtree(tmp_dir)

--- a/bottomdetection/docker_main.py
+++ b/bottomdetection/docker_main.py
@@ -8,6 +8,9 @@ Licensed under the MIT license.
 
 import os
 import sys
+import dask
+
+from dask.distributed import Client
 
 from bottomdetection import bottom_detection_main
 
@@ -23,6 +26,10 @@ if __name__ == "__main__":
 
     in_dir = os.path.expanduser("/in_dir")
     out_dir = os.path.expanduser("/out_dir")
+
+    dask.config.set({'temporary_directory': out_dir})
+    client = Client()
+    print(client)
 
     bottom_detection_main.run(zarr_file=in_dir + '/' + input_name,
                               out_file=out_dir + '/' + output_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+dask
 dask[array]
+dask[distributed]
 numpy
 pandas
 pyarrow


### PR DESCRIPTION
* The program crashes on Nautilus server. Solved by using `dask.distributed` to limit the number of parallel workers.
* Use the up to date naming for the resulting parquet files (ref. `annotationtools` package).  